### PR TITLE
Fix/fix login popup issue

### DIFF
--- a/src/components/layout/main-layout.tsx
+++ b/src/components/layout/main-layout.tsx
@@ -29,7 +29,6 @@ export function MainLayout({ children }: MainLayoutProps) {
   }
 
   if (!isAuthenticated) {
-    console.log("Login form triggered")
     return <LoginForm />;
   }
 

--- a/src/components/layout/main-layout.tsx
+++ b/src/components/layout/main-layout.tsx
@@ -29,6 +29,7 @@ export function MainLayout({ children }: MainLayoutProps) {
   }
 
   if (!isAuthenticated) {
+    console.log("Login form triggered")
     return <LoginForm />;
   }
 

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -86,6 +86,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           localStorage.removeItem('auth-data');
         }
       }
+      // Only set isLoading false after initializing auth
       setIsLoading(false);
     };
 
@@ -95,7 +96,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // Auto-fetch user data when we have a token but no user
   useEffect(() => {
     if (meQuery.data) {
-      setUser({...meQuery.data.user, role: meQuery.data.user.role as 'owner' | 'admin' | 'manager' | 'user' | 'guest', permissions: [...meQuery.data.user.permissions]});
+      setUser({
+        ...meQuery.data.user,
+        role: meQuery.data.user.role as 'owner' | 'admin' | 'manager' | 'user' | 'guest',
+        permissions: [...meQuery.data.user.permissions],
+      });
       setTenant(meQuery.data.tenant);
     }
   }, [meQuery.data]);
@@ -143,7 +148,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         refreshToken: result.refreshToken,
       };
 
-      setUser({...result.user, role: result.user.role as 'owner' | 'admin' | 'manager' | 'user' | 'guest', permissions: [...result.user.permissions]});
+      setUser({
+        ...result.user,
+        role: result.user.role as 'owner' | 'admin' | 'manager' | 'user' | 'guest',
+        permissions: [...result.user.permissions],
+      });
       setTenant(result.tenant);
       setAccessToken(result.accessToken);
       
@@ -171,7 +180,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         refreshToken: null,
       };
 
-      setUser({...result.user, role: result.user.role as 'owner' | 'admin' | 'manager' | 'user' | 'guest', permissions: [...result.user.permissions]});
+      setUser({
+        ...result.user,
+        role: result.user.role as 'owner' | 'admin' | 'manager' | 'user' | 'guest',
+        permissions: [...result.user.permissions],
+      });
       setTenant(result.tenant);
       
       localStorage.setItem('auth-data', JSON.stringify(authData));
@@ -195,7 +208,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // This would trigger the meQuery to refetch
       const result = await meQuery.refetch();
       if (result.data) {
-        setUser({...result.data.user, role: result.data.user.role as 'owner' | 'admin' | 'manager' | 'user' | 'guest', permissions: [...result.data.user.permissions]});
+        setUser({
+          ...result.data.user,
+          role: result.data.user.role as 'owner' | 'admin' | 'manager' | 'user' | 'guest',
+          permissions: [...result.data.user.permissions],
+        });
         setTenant(result.data.tenant);
       }
     } catch (error) {
@@ -216,7 +233,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     isOwner,
     isAdmin,
     isManager,
-    isLoading: isLoading || loginMutation.isPending || signupMutation.isPending,
+    isLoading: isLoading || loginMutation.isPending || signupMutation.isPending || meQuery.isFetching,
     hasPermission,
     login,
     signup,


### PR DESCRIPTION
Fixed the login popup issue which was occurring when navigating across different pages after logging in. This popup was occurring because in "main-layout.tsx", it will automatically render the login page if it thinks we aren't authenticated. 

The reason why it thought we weren't authenticated even after logging in, was because in "auth-provider.tsx", everytime we navigate to a new page, the meQuery will fetch the current user, however the issue was that while it was fetching, we set loading to be finished which caused the user to not be found yet and make us look like we are unauthenticated.

Adding an extra condition to update the isLoading parameter to include whether the meQuery was finished querying has now fixed the issue.